### PR TITLE
Fix provisioning on ubuntu system

### DIFF
--- a/cookbooks/mysql/recipes/client.rb
+++ b/cookbooks/mysql/recipes/client.rb
@@ -57,6 +57,12 @@ when "centos","redhat", "suse", "fedora"
   end
 
 else
+  b = package "build-essential" do
+    action :nothing
+  end
+
+  b.run_action(:install)
+
   r = gem_package "mysql" do
     action :nothing
   end


### PR DESCRIPTION
Make sure, that build-essential package is installed before trying to install gem mysql,
which tries to build native extensions.
