### PR TITLE
Readme fix

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,16 +8,13 @@ How
 
         gem install vagrant
 2. Download and Install [VirtualBox](http://www.virtualbox.org/)
-3. Download a vagrant box (name of the box is supposed to be lucid32)
-
-        vagrant box add lucid32 http://files.vagrantup.com/lucid32.box
-4. Clone this repo
-5. Go to the repo and launch the box
+3. Clone this repo
+4. Go to the repo and launch the box
 
         cd [repo]
         vagrant up
 
-6. Add this line to your `/etc/hosts` (or windows equivalent)
+5. Add this line to your `/etc/hosts` (or windows equivalent)
     127.0.0.1 www.dev-site.com dev-site.com dev.dev-site-static.com    
 
 That's it, the file in [repo]/public/ are served here : [http://www.dev-site.com:8080/](http://www.dev-site.com:8080/)

--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,6 @@ How
 5. Go to the repo and launch the box
 
         cd [repo]
-        vagrant init
         vagrant up
 
 6. Add this line to your `/etc/hosts` (or windows equivalent)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@ Vagrant::Config.run do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "lucid32"
+  config.vm.box_url = "http://files.vagrantup.com/lucid32.box"
 
   config.vm.provision :chef_solo do |chef|
     chef.cookbooks_path = "cookbooks"


### PR DESCRIPTION
Streamline installation process, by downloading basebox automatically.
Small README fix, to not call `vagrant init`.
