### PR TITLE
Fixes legacy port forwarding in Vagrantfile.pkg

### DIFF
--- a/Vagrantfile.pkg
+++ b/Vagrantfile.pkg
@@ -1,4 +1,4 @@
 Vagrant::Config.run do |config|
-  config.vm.forward_port("http", 80, 8080)
-  config.vm.forward_port("mysql", 3306, 3306)
+  config.vm.forward_port 80, 8080
+  config.vm.forward_port 3306, 3306
 end


### PR DESCRIPTION
```
% vagrant up
../vagrant/config/vm.rb:44:in to_s': wrong number of arguments(1 for 0) (ArgumentError)
```

Reference:
https://github.com/rtfd/readthedocs.org/pull/177
